### PR TITLE
Add further fixes to the airdop

### DIFF
--- a/project/SPT.Custom/Patches/FixAirdropCrashPatch.cs
+++ b/project/SPT.Custom/Patches/FixAirdropCrashPatch.cs
@@ -8,19 +8,19 @@ using Comfort.Common;
 
 namespace SPT.Custom.Patches
 {
-	/// <summary>
-	/// This patch prevents the crashing that was caused by the airdrop since the mortar event, it fully unloads whatever synchronized objects
-	/// Are still loaded before unused resources are cleaned up (Which causes this crash)
-	/// </summary>
-	public class FixAirdropCrashPatch : ModulePatch
-	{
-		protected override MethodBase GetTargetMethod()
-		{
-			return typeof(TarkovApplication).GetMethod(nameof(TarkovApplication.method_48));
-		}
+    /// <summary>
+    /// This patch prevents the crashing that was caused by the airdrop since the mortar event, it fully unloads whatever synchronized objects
+    /// Are still loaded before unused resources are cleaned up (Which causes this crash)
+    /// </summary>
+    public class FixAirdropCrashPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return typeof(TarkovApplication).GetMethod(nameof(TarkovApplication.method_48));
+        }
 
-		[PatchPrefix]
-		public static void Prefix()
+        [PatchPrefix]
+        public static void Prefix()
         {
             if (!Singleton<GameWorld>.Instantiated)
             {
@@ -45,16 +45,16 @@ namespace SPT.Custom.Patches
                 obj.ReturnToPool();
             }
 
-			// Without this check can cause black screen when backing out of raid prior to airdrop manager being init
-			if (gameWorld.SynchronizableObjectLogicProcessor.AirdropManager is not null)
+            // Without this check can cause black screen when backing out of raid prior to airdrop manager being init
+            if (gameWorld.SynchronizableObjectLogicProcessor.AirdropManager is not null)
             {
-				if (gameWorld.SynchronizableObjectLogicProcessor is SynchronizableObjectLogicProcessorClass synchronizableObjectLogicProcessorClass)
-				{
-					synchronizableObjectLogicProcessorClass.ServerAirdropManager.Dispose();
-				}
+                if (gameWorld.SynchronizableObjectLogicProcessor is SynchronizableObjectLogicProcessorClass synchronizableObjectLogicProcessorClass)
+                {
+                    synchronizableObjectLogicProcessorClass.ServerAirdropManager.Dispose();
+                }
 
-				gameWorld.SynchronizableObjectLogicProcessor.Dispose();
+                gameWorld.SynchronizableObjectLogicProcessor.Dispose();
             }
         }
-	}
+    }
 }

--- a/project/SPT.Custom/Patches/FixAirdropCrashPatch.cs
+++ b/project/SPT.Custom/Patches/FixAirdropCrashPatch.cs
@@ -45,10 +45,15 @@ namespace SPT.Custom.Patches
                 obj.ReturnToPool();
             }
 
-            // Without this check can cause black screen when backing out of raid prior to airdrop manager being init
-            if (gameWorld.SynchronizableObjectLogicProcessor.AirdropManager is not null)
+			// Without this check can cause black screen when backing out of raid prior to airdrop manager being init
+			if (gameWorld.SynchronizableObjectLogicProcessor.AirdropManager is not null)
             {
-                gameWorld.SynchronizableObjectLogicProcessor.Dispose();
+				if (gameWorld.SynchronizableObjectLogicProcessor is SynchronizableObjectLogicProcessorClass synchronizableObjectLogicProcessorClass)
+				{
+					synchronizableObjectLogicProcessorClass.ServerAirdropManager.Dispose();
+				}
+
+				gameWorld.SynchronizableObjectLogicProcessor.Dispose();
             }
         }
 	}

--- a/project/SPT.Custom/Patches/FixAirdropFlareDisposePatch.cs
+++ b/project/SPT.Custom/Patches/FixAirdropFlareDisposePatch.cs
@@ -1,0 +1,33 @@
+﻿using SPT.Reflection.Patching;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace SPT.Custom.Patches
+{
+	/// <summary>
+	/// This patch prevents the weird pink smoke / flares that are still in the sky the next raid if a player has just extracted
+	/// while the airplane is dropping a crate
+	/// </summary>
+	public class FixAirdropFlareDisposePatch : ModulePatch
+	{
+		protected override MethodBase GetTargetMethod()
+		{
+			return typeof(GClass2408).GetMethod(nameof(GClass2408.Dispose));
+		}
+
+		[PatchPrefix]
+		public static void Prefix(Dictionary<GameObject, float> ___dictionary_0)
+		{
+			if (___dictionary_0 == null)
+			{
+				return;
+			}
+
+			foreach (KeyValuePair<GameObject, float> keyValuePair in ___dictionary_0)
+			{
+				Object.Destroy(keyValuePair.Key);
+			}
+		}
+	}
+}

--- a/project/SPT.Custom/SPTCustomPlugin.cs
+++ b/project/SPT.Custom/SPTCustomPlugin.cs
@@ -38,15 +38,15 @@ namespace SPT.Custom
                 new BotDifficultyPatch().Enable();
                 new VersionLabelPatch().Enable();
                 new FixScavWarNullErrorWithMarkOfUnknownPatch().Enable();
-				new MergeScavPmcQuestsOnInventoryLoadPatch().Enable();
+                new MergeScavPmcQuestsOnInventoryLoadPatch().Enable();
                 new CopyPmcQuestsToPlayerScavPatch().Enable();
                 new FixBossesHavingNoFollowersOnMediumAiAmount().Enable();
                 new FixAirdropCrashPatch().Enable();
                 new FixAirdropFlareDisposePatch().Enable();
-				//new AllowAirdropsInPvEPatch().Enable();
-				new MemoryCollectionPatch().Enable();
+                //new AllowAirdropsInPvEPatch().Enable();
+                new MemoryCollectionPatch().Enable();
 
-				HookObject.AddOrGetComponent<MenuNotificationManager>();
+                HookObject.AddOrGetComponent<MenuNotificationManager>();
             }
             catch (Exception ex)
             {

--- a/project/SPT.Custom/SPTCustomPlugin.cs
+++ b/project/SPT.Custom/SPTCustomPlugin.cs
@@ -42,8 +42,9 @@ namespace SPT.Custom
                 new CopyPmcQuestsToPlayerScavPatch().Enable();
                 new FixBossesHavingNoFollowersOnMediumAiAmount().Enable();
                 new FixAirdropCrashPatch().Enable();
+                new FixAirdropFlareDisposePatch().Enable();
 				//new AllowAirdropsInPvEPatch().Enable();
-                new MemoryCollectionPatch().Enable();
+				new MemoryCollectionPatch().Enable();
 
 				HookObject.AddOrGetComponent<MenuNotificationManager>();
             }


### PR DESCRIPTION
This fixes the issues that were still open with the airdrop, namely:

- The notification spam when launching another flare in the second raid
- The flares and chaff still being in the sky with a pink texture from the previous raid