### PR TITLE
Change log to info

### DIFF
--- a/project/SPT.SinglePlayer/Patches/RaidFix/OverrideMaxAiAliveInRaidValuePatch.cs
+++ b/project/SPT.SinglePlayer/Patches/RaidFix/OverrideMaxAiAliveInRaidValuePatch.cs
@@ -37,7 +37,7 @@ namespace SPT.SinglePlayer.Patches.RaidFix
 
             if (int.TryParse(RequestHandler.GetJson($"/singleplayer/settings/bot/maxCap/{location}"), out var parsedMaxCount))
             {
-                Logger.LogError($"Set max bot cap for: {location} from: {maxCount} to: {parsedMaxCount}");
+                Logger.LogInfo($"Set max bot cap for: {location} from: {maxCount} to: {parsedMaxCount}");
                 maxCount = parsedMaxCount;
             }
             else


### PR DESCRIPTION
This is logging with `LogError()` when it's not an error, giving me a heart attach on every raid start.