### PR TITLE
Add a new patch that makes the server authoritative for Location data on match start

### DIFF
--- a/project/SPT.Custom/Patches/MatchStartServerLocationPatch.cs
+++ b/project/SPT.Custom/Patches/MatchStartServerLocationPatch.cs
@@ -1,0 +1,104 @@
+﻿using EFT;
+using HarmonyLib;
+using JsonType;
+using MonoMod.Cil;
+using SPT.Reflection.CodeWrapper;
+using SPT.Reflection.Patching;
+using SPT.Reflection.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SPT.Custom.Patches
+{
+    /**
+     * The purpose of this patch is to use the Location data returned from a `/client/match/local/start` call
+     * as the authoritative location data during match start, instead of the data cached at session start
+     */
+    internal class MatchStartServerLocationPatch : ModulePatch
+    {
+        private static Type nestedType = typeof(TarkovApplication).GetNestedTypes(PatchConstants.PublicDeclaredFlags).SingleCustom(IsTargetNestedType);
+        private static Type desiredType = typeof(TarkovApplication).GetNestedTypes(PatchConstants.PublicDeclaredFlags).SingleCustom(IsDesiredType);
+
+        protected override MethodBase GetTargetMethod()
+        {
+            var desiredMethod = desiredType.GetMethods(PatchConstants.PublicDeclaredFlags)
+                .FirstOrDefault(x => x.Name == "MoveNext");
+
+            Logger.LogDebug($"{this.GetType().Name} Type: {desiredType?.Name}");
+            Logger.LogDebug($"{this.GetType().Name} Method: {desiredMethod?.Name}");
+            Logger.LogDebug($"{this.GetType().Name} Nested Type: {nestedType?.Name}");
+
+            return desiredMethod;
+        }
+
+        [PatchTranspiler]
+        public static IEnumerable<CodeInstruction> PatchTranspile(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
+        {
+            var codes = new List<CodeInstruction>(instructions);
+
+            // Search for the code where `result.serverId` gets assigned
+            var searchCode = new CodeInstruction(OpCodes.Stfld, AccessTools.Field(typeof(LocalRaidSettings), nameof(LocalRaidSettings.serverId)));
+            var searchIndex = -1;
+            for (var i = 0; i < codes.Count; i++)
+            {
+                if (codes[i].opcode == searchCode.opcode && codes[i].operand == searchCode.operand)
+                {
+                    // Jump ahead one to get past the current assignment
+                    searchIndex = i + 1;
+                    break;
+                }
+            }
+
+            // Failed to find the target code
+            if (searchIndex == -1)
+            {
+                Logger.LogError($"Patch {MethodBase.GetCurrentMethod()} failed: Could not find reference code.");
+                return instructions;
+            }
+
+            // Find the target field (The @class variable)
+            var targetField = AccessTools.GetDeclaredFields(desiredType).FirstOrDefault(x => x.FieldType == nestedType);
+            if (targetField == null)
+            {
+                Logger.LogError($"Patch {MethodBase.GetCurrentMethod()} failed: Could not find target field.");
+                return instructions;
+            }
+
+            // Generate and inject the new IL
+            var newCodes = CodeGenerator.GenerateInstructions(new List<Code>()
+            {
+                /**
+                 * Inject the following assignment:
+                 *   @class.location = result.locationLoot;
+                 */
+                new Code(OpCodes.Ldarg_0), // ldarg.0 is `@class`
+                new Code(OpCodes.Ldfld, desiredType, targetField.Name),
+                new Code(OpCodes.Ldloc_2), // ldloc.2 is `localSettings`
+                new Code(OpCodes.Ldfld, typeof(LocalSettings), nameof(LocalSettings.locationLoot)),
+                new Code(OpCodes.Stfld, nestedType, "location"),
+            });
+            codes.InsertRange(searchIndex, newCodes);
+
+            return codes.AsEnumerable();
+        }
+
+        private static bool IsDesiredType(Type type)
+        {
+            return type.GetField("timeAndWeather") != null &&
+                   type.GetField("tarkovApplication_0") != null &&
+                   type.GetField("gameWorld") != null &&
+                   type.Name.Contains("Struct");
+        }
+
+        private static bool IsTargetNestedType(Type nestedType)
+        {
+            return nestedType.GetMethods(PatchConstants.PublicDeclaredFlags).Any() &&
+                   nestedType.GetFields().Length == 5 &&
+                   nestedType.GetField("savageProfile") != null &&
+                   nestedType.GetField("profile") != null;
+        }
+    }
+}

--- a/project/SPT.Custom/SPTCustomPlugin.cs
+++ b/project/SPT.Custom/SPTCustomPlugin.cs
@@ -50,6 +50,7 @@ namespace SPT.Custom
 
                 // 3.11
                 new EnablePrestigeTabPatch().Enable();
+                new MatchStartServerLocationPatch().Enable();
 
                 HookObject.AddComponent<MenuNotificationManager>();
             }

--- a/project/SPT.SinglePlayer/Patches/RaidFix/PmcBotSidePatch.cs
+++ b/project/SPT.SinglePlayer/Patches/RaidFix/PmcBotSidePatch.cs
@@ -1,13 +1,7 @@
 ﻿using EFT;
 using HarmonyLib;
 using SPT.Reflection.Patching;
-using SPT.Reflection.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SPT.SinglePlayer.Patches.RaidFix
 {

--- a/project/SPT.SinglePlayer/Patches/RaidFix/PmcBotSidePatch.cs
+++ b/project/SPT.SinglePlayer/Patches/RaidFix/PmcBotSidePatch.cs
@@ -1,0 +1,46 @@
+﻿using EFT;
+using HarmonyLib;
+using SPT.Reflection.Patching;
+using SPT.Reflection.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SPT.SinglePlayer.Patches.RaidFix
+{
+    /**
+     * The purpose of this patch is to assign the correct `Side` to PMC bots after their profile has been
+     * pulled from the server.
+     * 
+     * This is required, as the data coming back from the server needs to have the Side set to Savage, which
+     * breaks certain things like armband slots, and non-lootable melee weapons
+     */
+    internal class PmcBotSidePatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return AccessTools.Method(typeof(BotCreationDataClass), nameof(BotCreationDataClass.ChooseProfile));
+        }
+
+        [PatchPostfix]
+        public static void PatchPostfix(ref Profile __result)
+        {
+            if (__result == null)
+            {
+                return;
+            }
+
+            if (__result.Info.Settings.Role == WildSpawnType.pmcBEAR)
+            {
+                __result.Info.Side = EPlayerSide.Bear;
+            }
+            else if (__result.Info.Settings.Role == WildSpawnType.pmcUSEC)
+            {
+                __result.Info.Side = EPlayerSide.Usec;
+            }
+        }
+    }
+}

--- a/project/SPT.SinglePlayer/Patches/ScavMode/ScavLateStartPatch.cs
+++ b/project/SPT.SinglePlayer/Patches/ScavMode/ScavLateStartPatch.cs
@@ -14,16 +14,11 @@ using SPT.SinglePlayer.Models.ScavMode;
 namespace SPT.SinglePlayer.Patches.ScavMode
 {
     /// <summary>
-    /// Make alterations to the _raidSettings values prior to them being used to create a local game
-    /// ____raidSettings.SelectedLocation.EscapeTimeLimit
-    /// ____raidSettings.SelectedLocation.exits
+    /// Make alterations to the the suurvive time requirement prior to it being used to create a local game
     /// Singleton<BackendConfigSettingsClass>.Instance.Experience.MatchEnd.SurvivedTimeRequirement
     /// </summary>
     public class ScavLateStartPatch : ModulePatch
     {
-        // A cache of Location settings before any edits were made
-        private static readonly Dictionary<string, LocationSettingsClass.Location> originalLocationSettings = new();
-
         protected override MethodBase GetTargetMethod()
         {
             var desiredType = typeof(TarkovApplication);
@@ -53,12 +48,6 @@ namespace SPT.SinglePlayer.Patches.ScavMode
         {
             var currentMapId = ____raidSettings.SelectedLocation.Id;
 
-            // Cache map info for use later 
-            if (!originalLocationSettings.ContainsKey(currentMapId))
-            {
-                originalLocationSettings.Add(currentMapId, ____raidSettings.SelectedLocation);
-            }
-
             // Create request and send to server, parse response
             var request = new RaidTimeRequest(____raidSettings.Side, currentMapId);
             var json = RequestHandler.PostJson("/singleplayer/settings/getRaidTime", Json.Serialize(request));
@@ -67,76 +56,15 @@ namespace SPT.SinglePlayer.Patches.ScavMode
             // Capture the changes that will be made to the raid so they can be easily accessed by modders
             Utils.InRaid.RaidChangesUtil.UpdateRaidChanges(____raidSettings, serverResult);
 
-            // Set new raid time
-            ____raidSettings.SelectedLocation.EscapeTimeLimit = serverResult.RaidTimeMinutes;
-
             // Handle survival time changes
             AdjustSurviveTimeForExtraction(serverResult.NewSurviveTimeSeconds.HasValue
                 ? serverResult.NewSurviveTimeSeconds.Value
                 : serverResult.OriginalSurvivalTimeSeconds);
 
-            // Handle exit changes
-            ResetMapExits(____raidSettings.SelectedLocation, originalLocationSettings[currentMapId]);
-            if (serverResult.ExitChanges != null && serverResult.ExitChanges.Count > 0)
-            {
-                AdjustMapExits(____raidSettings.SelectedLocation, serverResult.ExitChanges);
-            }
-
             // Confirm that all raid changes are complete
             Utils.InRaid.RaidChangesUtil.ConfirmRaidChanges();
 
             return true; // Do original method
-        }
-
-        private static void AdjustMapExits(LocationSettingsClass.Location location, List<ExitChanges> exitChangesToApply)
-        {
-            // Loop over each exit change from server
-            foreach (var exitChange in exitChangesToApply)
-            {
-                // Find the client exit we want to make changes to
-                var exitToChange = location.exits.FirstOrDefault(x => x.Name == exitChange.Name);
-                if (exitToChange == null)
-                {
-                    Logger.LogDebug($"Exit with Id: {exitChange.Name} not found, skipping");
-                    continue;
-                }
-
-                if (exitChange.Chance.HasValue)
-                {
-                    exitToChange.Chance = exitChange.Chance.Value;
-                }
-
-                if (exitChange.MinTime.HasValue)
-                {
-                    exitToChange.MinTime = exitChange.MinTime.Value;
-                }
-
-                if (exitChange.MaxTime.HasValue)
-                {
-                    exitToChange.MaxTime = exitChange.MaxTime.Value;
-                }
-            }
-        }
-
-        private static void ResetMapExits(LocationSettingsClass.Location clientLocation, LocationSettingsClass.Location cachedLocation)
-        {
-            // Iterate over cached original map data
-            foreach (var cachedExit in cachedLocation.exits)
-            {
-                // Find client exit
-                var clientLocationExit = clientLocation.exits.FirstOrDefault(x => x.Name == cachedExit.Name);
-                if (clientLocationExit == null)
-                {
-                    Logger.LogDebug($"Unable to find exit with name: {cachedExit.Name}, skipping");
-
-                    continue;
-                }
-
-                // Reset values to those from cache
-                clientLocationExit.Chance = cachedExit.Chance;
-                clientLocationExit.MinTime = cachedExit.MinTime;
-                clientLocationExit.MaxTime = cachedExit.MaxTime;
-            }
         }
 
         private static void AdjustSurviveTimeForExtraction(int newSurvivalTimeSeconds)

--- a/project/SPT.SinglePlayer/SPTSingleplayerPlugin.cs
+++ b/project/SPT.SinglePlayer/SPTSingleplayerPlugin.cs
@@ -68,6 +68,7 @@ namespace SPT.SinglePlayer
 				new RemoveStopwatchAllocationsEveryBotFramePatch().Enable();
 				new RemoveStopwatchAllocationsEveryCoverPointFramePatch().Enable();
 				new DisableUseBSGServersCheckbox().Enable();
+				new PmcBotSidePatch().Enable();
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
- New `MatchStartServerLocationPatch` patch that sets `@class.location = localSettings.locationLoot` on match start
- Refactor ScavLateStartPatch to only handle setting SurvivedTimeRequirement, everything else is moved to server