### PR TITLE
Update for https-rework

### DIFF
--- a/project/SPT.Common/Http/Client.cs
+++ b/project/SPT.Common/Http/Client.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
+using System.Security.Authentication;
 using System.Text;
 using System.Threading.Tasks;
 using SPT.Common.Utils;
@@ -25,7 +27,10 @@ namespace SPT.Common.Http
             var handler = new HttpClientHandler
             {
                 // set cookies in header instead
-                UseCookies = false
+                UseCookies = false,
+
+                // Bypass Cert validation in the httpServer - discard arguments as we dont use them
+                ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
             };
 
             _httpv = new HttpClient(handler);

--- a/project/SPT.Core/SPTCorePlugin.cs
+++ b/project/SPT.Core/SPTCorePlugin.cs
@@ -25,8 +25,10 @@ namespace SPT.Core
                 new BattlEyePatch().Enable();
                 new SslCertificatePatch().Enable();
                 new UnityWebRequestPatch().Enable();
-                new WebSocketPatch().Enable();
-                new TransportPrefixPatch().Enable();
+                
+                // No longer needed with us moving back to Https
+                // new WebSocketPatch().Enable();
+                // new TransportPrefixPatch().Enable();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Update to nolonger change from https to http

this fixes issues with external connections over http. (this is a unity 22 thing)