### PR TITLE
Fix hitting "Ready" on the Practice Raid screen while starting a scav run

### DIFF
--- a/project/SPT.SinglePlayer/Patches/ScavMode/LoadOfflineRaidScreenPatch.cs
+++ b/project/SPT.SinglePlayer/Patches/ScavMode/LoadOfflineRaidScreenPatch.cs
@@ -131,7 +131,7 @@ namespace SPT.SinglePlayer.Patches.ScavMode
             gclass.OnShowNextScreen += LoadOfflineRaidNextScreen;
 
             // `MatchmakerOfflineRaidScreen` OnShowReadyScreen
-            gclass.OnShowReadyScreen += (OfflineRaidAction)Delegate.CreateDelegate(typeof(OfflineRaidAction), menuController, nameof(MainMenuControllerClass.method_79));
+            gclass.OnShowReadyScreen += (OfflineRaidAction)Delegate.CreateDelegate(typeof(OfflineRaidAction), menuController, nameof(MainMenuControllerClass.method_80));
             gclass.ShowScreen(EScreenState.Queued);
         }
 


### PR DESCRIPTION
Fixes hitting "Ready" on the "Practice Game Mode" screen during a scav run showing the PMC insurance screen