### PR TITLE
Allow tracking non-wave spawns to AI PMCs

### DIFF
--- a/project/SPT.Custom/Patches/SpawnPointAIPlayerBotLimitPatch.cs
+++ b/project/SPT.Custom/Patches/SpawnPointAIPlayerBotLimitPatch.cs
@@ -1,0 +1,76 @@
+﻿using Comfort.Common;
+using EFT;
+using EFT.Game.Spawning;
+using HarmonyLib;
+using SPT.Custom.CustomAI;
+using SPT.Reflection.Patching;
+using System.Reflection;
+using UnityEngine;
+
+namespace SPT.Custom.Patches
+{
+    /**
+     * The purpose of this patch is to include AI PMCs in the individual limit checks for non-wave
+     * spawn caps. This is to better mimic live PvP spawn behaviour, while not drastically increasing
+     * the total spawn cap for each map
+     */
+    public class SpawnPointAIPlayerBotLimitPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return AccessTools.Method(typeof(SpawnPoint), nameof(SpawnPoint.IsInPlayersIndividualLimits));
+        }
+
+        /**
+         * Re-implement the original `IsInPlayersIndividualLimits` but including AI PMCs
+         */
+        [PatchPrefix]
+        public static bool PatchPrefix(ref bool __result, BotCreationDataClass creationData, Vector3 ___Position)
+        {
+            if (creationData == null)
+            {
+                __result = true;
+                return false;
+            }
+
+            foreach (Profile profile in creationData.Profiles)
+            {
+                if ((profile.Info.Settings.Role.IsBossOrFollower() || profile.Info.Settings.Role == WildSpawnType.marksman) && profile.Info.Settings.Role != WildSpawnType.assaultGroup)
+                {
+                    __result = true;
+                    return false;
+                }
+            }
+
+            BotsController botsController = Singleton<IBotGame>.Instance?.BotsController;
+            if (botsController != null)
+            {
+                float minDistance = float.MaxValue;
+                Player closestPlayer = null;
+                foreach (Player player in Singleton<GameWorld>.Instance.AllAlivePlayersList)
+                {
+                    if (!player.IsAI || AiHelpers.BotIsSptPmc(player.Profile.Info.Settings.Role, player.AIData.BotOwner))
+                    {
+                        float dist = ___Position.SqrDistance(player.Position);
+                        if (dist < minDistance)
+                        {
+                            minDistance = dist;
+                            closestPlayer = player;
+                        }
+                    }
+                }
+
+                if (closestPlayer != null)
+                {
+                    __result = botsController.BotSpawnLimiter.IsInPlayerSpawnLimit(closestPlayer, creationData);
+                    return false;
+                }
+            }
+
+            __result = false;
+
+            // Skip original
+            return false;
+        }
+    }
+}

--- a/project/SPT.Custom/Patches/SpawnPointNearestPlayerAIPatch.cs
+++ b/project/SPT.Custom/Patches/SpawnPointNearestPlayerAIPatch.cs
@@ -1,0 +1,58 @@
+﻿
+using Comfort.Common;
+using EFT;
+using EFT.Game.Spawning;
+using HarmonyLib;
+using SPT.Custom.CustomAI;
+using SPT.Reflection.Patching;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace SPT.Custom.Patches
+{
+    /**
+     * The purpose of this patch is to include AI PMCs in the Nearest Player result list for 
+     * the SpawnPoint class. This allows AI PMCs to have spawns tracked based on their ID instead
+     * of all spawns being tracked to the main player
+     */
+    public class SpawnPointNearestPlayerAIPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return AccessTools.FirstMethod(typeof(SpawnPoint), (method) => method.ReturnType == typeof(Player));
+        }
+
+        /**
+         * Re-implement the original method, but including AI PMCs
+         */
+        [PatchPrefix]
+        public static bool PatchPrefix(ref Player __result, Vector3 ___Position)
+        {
+            List<Player> allAlivePlayersList = Singleton<GameWorld>.Instance.AllAlivePlayersList;
+            Player closestPlayer = null;
+            float minDistance = float.MaxValue;
+            if (Singleton<IBotGame>.Instance?.BotsController != null)
+            {
+                foreach (Player player in allAlivePlayersList)
+                {
+                    // Skip if this is an AI bot who isn't a PMC
+                    if (player.IsAI && !AiHelpers.BotIsSptPmc(player.Profile.Info.Settings.Role, player.AIData.BotOwner)) continue;
+                    if (!player.HealthController.IsAlive) continue;
+
+                    float dist = ___Position.SqrDistance(player.Position);
+                    if (dist < minDistance)
+                    {
+                        minDistance = dist;
+                        closestPlayer = player;
+                    }
+                }
+            }
+
+            __result = closestPlayer;
+
+            // Skip original
+            return false;
+        }
+    }
+}

--- a/project/SPT.Custom/SPTCustomPlugin.cs
+++ b/project/SPT.Custom/SPTCustomPlugin.cs
@@ -55,6 +55,8 @@ namespace SPT.Custom
                 // 3.11
                 new EnablePrestigeTabPatch().Enable();
                 new MatchStartServerLocationPatch().Enable();
+                new SpawnPointAIPlayerBotLimitPatch().Enable();
+                new SpawnPointNearestPlayerAIPatch().Enable();
 
                 HookObject.AddComponent<MenuNotificationManager>();
             }


### PR DESCRIPTION
Allow tracking non-wave spawns to AI PMCs alongside the main player PMC.
This helps partially resolve scavs no longer spawning after killing too many scavs