### PR TITLE
Fix ambiguous reference error in rider

### DIFF
--- a/project/SPT.Custom/Patches/SpawnPointAIPlayerBotLimitPatch.cs
+++ b/project/SPT.Custom/Patches/SpawnPointAIPlayerBotLimitPatch.cs
@@ -51,7 +51,7 @@ namespace SPT.Custom.Patches
                 {
                     if (!player.IsAI || AiHelpers.BotIsSptPmc(player.Profile.Info.Settings.Role, player.AIData.BotOwner))
                     {
-                        float dist = ___Position.SqrDistance(player.Position);
+                        float dist = ___Position.SqrDistance(((IPlayer)player).Position);
                         if (dist < minDistance)
                         {
                             minDistance = dist;

--- a/project/SPT.Custom/Patches/SpawnPointNearestPlayerAIPatch.cs
+++ b/project/SPT.Custom/Patches/SpawnPointNearestPlayerAIPatch.cs
@@ -40,7 +40,7 @@ namespace SPT.Custom.Patches
                     if (player.IsAI && !AiHelpers.BotIsSptPmc(player.Profile.Info.Settings.Role, player.AIData.BotOwner)) continue;
                     if (!player.HealthController.IsAlive) continue;
 
-                    float dist = ___Position.SqrDistance(player.Position);
+                    float dist = ___Position.SqrDistance(((IPlayer)player).Position);
                     if (dist < minDistance)
                     {
                         minDistance = dist;


### PR DESCRIPTION
Adds an explicit cast to avoid an ambiguous reference error due to a rider bug.