### PR TITLE
Fix PatchManager Only Finding Patch Types Directly Inheriting `ModulePatch`

### DIFF
--- a/project/SPT.Reflection/Patching/PatchManager.cs
+++ b/project/SPT.Reflection/Patching/PatchManager.cs
@@ -98,7 +98,7 @@ public class PatchManager
 
         foreach (var type in assembly.GetTypes())
         {
-            if (type.BaseType != baseType)
+            if (!baseType.IsAssignableFrom(type) || type.IsAbstract)
             {
                 continue;
             }


### PR DESCRIPTION
See https://github.com/sp-tarkov/server-csharp/pull/592

`Type.IsAssignableTo` doesn't exist here, so I changed it to using `IsAssignableFrom`