### PR TITLE
Don't log success on request failure

### DIFF
--- a/project/SPT.Common/Http/RequestHandler.cs
+++ b/project/SPT.Common/Http/RequestHandler.cs
@@ -46,6 +46,7 @@ public static class RequestHandler
         if (data == null)
         {
             _logger.LogError($"[REQUEST FAILED] {path}");
+            return;
         }
 
         _logger.LogInfo($"[REQUEST SUCCESSFUL] {path}");
@@ -56,6 +57,7 @@ public static class RequestHandler
         if (string.IsNullOrWhiteSpace(json))
         {
             _logger.LogError($"[REQUEST FAILED] {path}");
+            return;
         }
 
         _logger.LogInfo($"[REQUEST SUCCESSFUL] {path}");


### PR DESCRIPTION
`RequestHandler.ValidateData()` and `RequestHandler.ValidateJson()` currently log errors and then proceed to also log success due to missing returns. Simple fix.