### PR TITLE
Bug Fix for Player Scav Brain Swapping

### DIFF
--- a/project/SPT.Custom/CustomAI/AIExtensions.cs
+++ b/project/SPT.Custom/CustomAI/AIExtensions.cs
@@ -28,8 +28,20 @@ public static class AIExtensions
     /// </returns>
     public static bool IsSimulatedPlayerScav(this BotOwner botOwner)
     {
-        return botOwner.Profile.Info.Settings.Role == WildSpawnType.assault
-            && !string.IsNullOrEmpty(botOwner.Profile.Info.MainProfileNickname);
+        return botOwner.HasMainProfileNickname() && botOwner.Profile.Info.Settings.Role == WildSpawnType.assault;
+    }
+
+    /// <summary>
+    /// Determines if the bot has a PMC name in its main profile (which is set when the server generates player Scavs)
+    /// </summary>
+    /// <param name="botOwner">The bot owner instance to evaluate</param>
+    /// <returns>
+    /// <see langword="true"/> if the bot owner's main profile nickname is not empty <br/>
+    /// <see langword="false"/> otherwise
+    /// </returns>
+    public static bool HasMainProfileNickname(this BotOwner botOwner)
+    {
+        return !string.IsNullOrEmpty(botOwner.Profile.Info.MainProfileNickname);
     }
 
     public static List<BotOwner> GetAllMembers(this BotsGroup group)

--- a/project/SPT.Custom/Patches/CustomAiPatch.cs
+++ b/project/SPT.Custom/Patches/CustomAiPatch.cs
@@ -158,7 +158,7 @@ public class CustomAiPatch : ModulePatch
             // Set spt pmc bot back to original type
             __instance.BotOwner_0.Profile.Info.Settings.Role = __state;
         }
-        else if (__instance.BotOwner_0.IsSimulatedPlayerScav())
+        else if (__instance.BotOwner_0.HasMainProfileNickname() && __state == WildSpawnType.assault)
         {
             // Set pscav back to original type
             __instance.BotOwner_0.Profile.Info.Settings.Role = __state;


### PR DESCRIPTION
Fixes existing code that checks bots' current roles to determine if they should be reverted to their original values. This does not work for player Scavs because their roles will already have been changed in `PatchPrefix`, and therefore `IsSimulatedPlayerScav()` returns `false`. 