### PR TITLE
Json enum extensions

### DIFF
--- a/project/SPT.PrePatch/EnumEntryDefinition.cs
+++ b/project/SPT.PrePatch/EnumEntryDefinition.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+
+namespace SPT.PrePatch;
+
+public sealed class EnumEntryDefinition
+{
+    [JsonProperty("enumType")]
+    public string EnumType { get; set; }
+
+    [JsonProperty("constantName")]
+    public string ConstantName { get; set; }
+
+    [JsonProperty("jsonEnumName")]
+    public string JsonEnumName { get; set; }
+
+    [JsonProperty("constantValue")]
+    public long ConstantValue { get; set; }
+}

--- a/project/SPT.PrePatch/EnumPatcher.cs
+++ b/project/SPT.PrePatch/EnumPatcher.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BepInEx.Logging;
+using Mono.Cecil;
+
+namespace SPT.PrePatch;
+
+public static class EnumPatcher
+{
+    public static void PatchEnums(ManualLogSource logger, ref AssemblyDefinition assembly, IReadOnlyCollection<EnumEntryDefinition> entries)
+    {
+        if (entries is null || entries.Count == 0)
+        {
+            return;
+        }
+
+        logger.LogInfo($"Patching {entries.Count} enum entries");
+
+        foreach (var enumGroup in entries.GroupBy(entry => entry.EnumType))
+        {
+            var enumType = assembly.MainModule.GetType(enumGroup.Key);
+            if (enumType is null || !enumType.IsEnum)
+            {
+                throw new InvalidOperationException($"Could not find enum type '{enumGroup.Key}' in Assembly-CSharp.dll.");
+            }
+
+            foreach (var entry in enumGroup)
+            {
+                if (string.IsNullOrWhiteSpace(entry.ConstantName))
+                {
+                    throw new InvalidOperationException($"The server returned an enum entry with no name for '{enumGroup.Key}'.");
+                }
+
+                if (enumType.Fields.Any(field => field.Name == entry.ConstantName))
+                {
+                    throw new InvalidOperationException($"Enum '{enumGroup.Key}' already contains an entry named '{entry.ConstantName}'.");
+                }
+
+                if (enumType.Fields.Any(field => field.HasConstant && Convert.ToInt64(field.Constant) == entry.ConstantValue))
+                {
+                    throw new InvalidOperationException($"Enum '{enumGroup.Key}' already contains the value {entry.ConstantValue}.");
+                }
+
+                enumType.Fields.Add(
+                    CreateNewConstant(ref assembly, enumType, entry.JsonEnumName, entry.ConstantName, enumType, entry.ConstantValue)
+                );
+            }
+        }
+
+        logger.LogInfo($"Successfully patched {entries.Count} enum entries");
+    }
+
+    private static FieldDefinition CreateNewConstant(
+        ref AssemblyDefinition assembly,
+        TypeDefinition enumType,
+        string attributeName,
+        string enumName,
+        TypeDefinition enumClass,
+        long customConstant
+    )
+    {
+        var jsonEnumNameAttribute = assembly.MainModule.GetType("EFT.JsonEnumNameAttribute");
+        var ctor = jsonEnumNameAttribute.Methods.First(m => m.IsConstructor);
+        var attribute = new CustomAttribute(ctor);
+
+        var constant = new FieldDefinition(
+            enumName,
+            FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.Literal | FieldAttributes.HasDefault,
+            enumClass
+        )
+        {
+            Constant = ConvertConstant(enumType, customConstant),
+        };
+
+        if (!string.IsNullOrEmpty(attributeName))
+        {
+            var valueArgument = new CustomAttributeArgument(assembly.MainModule.TypeSystem.String, attributeName);
+            attribute.ConstructorArguments.Add(valueArgument);
+            constant.CustomAttributes.Add(attribute);
+        }
+
+        return constant;
+    }
+
+    private static object ConvertConstant(TypeDefinition enumType, long value)
+    {
+        var underlyingType = enumType.Fields.First(field => field.Name == "value__").FieldType.MetadataType;
+
+        try
+        {
+            return underlyingType switch
+            {
+                MetadataType.SByte => checked((sbyte)value),
+                MetadataType.Byte => checked((byte)value),
+                MetadataType.Int16 => checked((short)value),
+                MetadataType.UInt16 => checked((ushort)value),
+                MetadataType.Int32 => checked((int)value),
+                MetadataType.UInt32 => checked((uint)value),
+                MetadataType.Int64 => value,
+                MetadataType.UInt64 => checked((ulong)value),
+                _ => throw new ModLoaderException($"Enum `{enumType.Name}` has an unsupported underlying type `{underlyingType}`."),
+            };
+        }
+        catch (OverflowException exception)
+        {
+            throw new ModLoaderException(
+                $"Value {value} does not fit enum `{enumType.Name}` underlying type `{underlyingType}`.",
+                exception
+            );
+        }
+    }
+}

--- a/project/SPT.PrePatch/ModLoaderException.cs
+++ b/project/SPT.PrePatch/ModLoaderException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SPT.PrePatch;
+
+public sealed class ModLoaderException : Exception
+{
+    public ModLoaderException(string message)
+        : base(message) { }
+
+    public ModLoaderException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/project/SPT.PrePatch/SptPrePatcher.cs
+++ b/project/SPT.PrePatch/SptPrePatcher.cs
@@ -5,18 +5,66 @@ using System.Linq;
 using BepInEx.Logging;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Newtonsoft.Json;
 
 namespace SPT.PrePatch;
 
-public static class SPTPrePatcher
+public static class SptPrePatcher
 {
     public static IEnumerable<string> TargetDLLs { get; } = new[] { "Assembly-CSharp.dll" };
     private const string _sptPluginFolder = "plugins/spt";
+
+    private const string EnumEntriesRoute = "/singleplayer/customEnumEntries";
+
+    private static ManualLogSource _logger = Logger.CreateLogSource(nameof(SptPrePatcher));
 
     public static void Patch(ref AssemblyDefinition assembly)
     {
         PerformPreValidation();
         ChangeAppDataPath(assembly);
+
+        EnumPatcher.PatchEnums(_logger, ref assembly, GetCustomEnumEntries());
+    }
+
+    private static List<EnumEntryDefinition> GetCustomEnumEntries()
+    {
+        var backendUrl = GetBackendUrl();
+        var requestUri = new Uri(new Uri(backendUrl.TrimEnd('/') + "/"), EnumEntriesRoute.TrimStart('/'));
+
+        var response = WinHttpClient.GetString(requestUri);
+        if (string.IsNullOrWhiteSpace(response))
+        {
+            throw new InvalidOperationException($"The server returned an empty response from {EnumEntriesRoute}.");
+        }
+
+        var resp = JsonConvert.DeserializeObject<List<EnumEntryDefinition>>(response);
+        if (resp is null)
+        {
+            throw new InvalidOperationException($"The response from {EnumEntriesRoute} is null.");
+        }
+
+        return resp;
+    }
+
+    private static string GetBackendUrl()
+    {
+        const string configPrefix = "-config=";
+        var configArgument = Environment
+            .GetCommandLineArgs()
+            .FirstOrDefault(argument => argument.StartsWith(configPrefix, StringComparison.OrdinalIgnoreCase));
+
+        if (configArgument is null)
+        {
+            throw new InvalidOperationException("Could not find SPT's -config launch argument containing the backend URL.");
+        }
+
+        var launcherConfig = JsonConvert.DeserializeObject<LauncherConfig>(configArgument[configPrefix.Length..]);
+        if (string.IsNullOrWhiteSpace(launcherConfig?.BackendUrl))
+        {
+            throw new InvalidOperationException("SPT's -config launch argument did not contain a backend URL.");
+        }
+
+        return launcherConfig.BackendUrl;
     }
 
     private static void ChangeAppDataPath(AssemblyDefinition assembly)
@@ -102,13 +150,12 @@ public static class SPTPrePatcher
     private static bool ValidateSptPlugins(string sptPluginPath, out string message)
     {
         string exitMessage = "\n\nPlease re-install SPT. Exiting.";
-        ManualLogSource logger = Logger.CreateLogSource(nameof(SPTPrePatcher));
 
         // Validate that the SPT plugin path exists
         if (!Directory.Exists(sptPluginPath))
         {
             message = $"'{sptPluginPath}' directory not found{exitMessage}";
-            logger.LogError(message);
+            _logger.LogError(message);
             return false;
         }
 
@@ -128,12 +175,17 @@ public static class SPTPrePatcher
             if (!foundPlugins.Contains(pluginNameAndSuffix))
             {
                 message = $"Required SPT plugin: {pluginNameAndSuffix} missing from '{sptPluginPath}' {exitMessage}";
-                logger.LogError(message);
+                _logger.LogError(message);
                 return false;
             }
         }
 
         message = "";
         return true;
+    }
+
+    private sealed class LauncherConfig
+    {
+        public string BackendUrl { get; set; }
     }
 }

--- a/project/SPT.PrePatch/WinHttpClient.cs
+++ b/project/SPT.PrePatch/WinHttpClient.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SPT.PrePatch;
+
+/// <summary>
+///     Uses Windows WinHTTP because Mono's TLS provider is not initialized when prepatchers run.
+/// </summary>
+internal static class WinHttpClient
+{
+    private const uint AccessTypeNoProxy = 1;
+    private const uint FlagSecure = 0x00800000;
+    private const uint QueryStatusCode = 19;
+    private const uint QueryFlagNumber = 0x20000000;
+    private const uint OptionSecurityFlags = 31;
+    private const uint SecurityFlagIgnoreUnknownCa = 0x00000100;
+    private const uint SecurityFlagIgnoreCertWrongUsage = 0x00000200;
+    private const uint SecurityFlagIgnoreCertCnInvalid = 0x00001000;
+    private const uint SecurityFlagIgnoreCertDateInvalid = 0x00002000;
+
+    public static string GetString(Uri uri)
+    {
+        var session = IntPtr.Zero;
+        var connection = IntPtr.Zero;
+        var request = IntPtr.Zero;
+
+        try
+        {
+            session = WinHttpOpen("spt-prepatch/1.0", AccessTypeNoProxy, null, null, 0);
+            EnsureHandle(session, "open a WinHTTP session");
+
+            if (!WinHttpSetTimeouts(session, 10_000, 10_000, 10_000, 10_000))
+            {
+                ThrowLastError("configure WinHTTP timeouts");
+            }
+
+            connection = WinHttpConnect(session, uri.Host, checked((ushort)uri.Port), 0);
+            EnsureHandle(connection, "connect to the SPT server");
+
+            request = WinHttpOpenRequest(
+                connection,
+                "GET",
+                uri.PathAndQuery,
+                null,
+                null,
+                IntPtr.Zero,
+                uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? FlagSecure : 0
+            );
+            EnsureHandle(request, "create the SPT server request");
+
+            if (uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+            {
+                var securityFlags =
+                    SecurityFlagIgnoreUnknownCa
+                    | SecurityFlagIgnoreCertWrongUsage
+                    | SecurityFlagIgnoreCertCnInvalid
+                    | SecurityFlagIgnoreCertDateInvalid;
+
+                if (!WinHttpSetOption(request, OptionSecurityFlags, ref securityFlags, sizeof(uint)))
+                {
+                    ThrowLastError("configure the SPT HTTPS certificate policy");
+                }
+            }
+
+            if (!WinHttpSendRequest(request, null, 0, IntPtr.Zero, 0, 0, IntPtr.Zero))
+            {
+                ThrowLastError("send the SPT server request");
+            }
+
+            if (!WinHttpReceiveResponse(request, IntPtr.Zero))
+            {
+                ThrowLastError("receive the SPT server response");
+            }
+
+            var statusCode = GetStatusCode(request);
+            var responseBytes = ReadResponse(request);
+            var response = Encoding.UTF8.GetString(DecompressZlib(responseBytes));
+            if (statusCode < 200 || statusCode >= 300)
+            {
+                throw new InvalidOperationException($"The SPT server returned HTTP {statusCode}: {response}");
+            }
+
+            return response;
+        }
+        finally
+        {
+            CloseHandle(request);
+            CloseHandle(connection);
+            CloseHandle(session);
+        }
+    }
+
+    private static uint GetStatusCode(IntPtr request)
+    {
+        var statusCode = 0u;
+        var statusCodeSize = (uint)sizeof(uint);
+        if (!WinHttpQueryHeaders(request, QueryStatusCode | QueryFlagNumber, null, ref statusCode, ref statusCodeSize, IntPtr.Zero))
+        {
+            ThrowLastError("read the SPT server status code");
+        }
+
+        return statusCode;
+    }
+
+    private static byte[] ReadResponse(IntPtr request)
+    {
+        using var stream = new MemoryStream();
+
+        while (true)
+        {
+            if (!WinHttpQueryDataAvailable(request, out var available))
+            {
+                ThrowLastError("query the SPT response size");
+            }
+
+            if (available == 0)
+            {
+                break;
+            }
+
+            var buffer = new byte[available];
+            if (!WinHttpReadData(request, buffer, available, out var bytesRead))
+            {
+                ThrowLastError("read the SPT server response");
+            }
+
+            stream.Write(buffer, 0, checked((int)bytesRead));
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] DecompressZlib(byte[] response)
+    {
+        if (!HasZlibHeader(response))
+        {
+            return response;
+        }
+
+        // A zlib stream wraps raw DEFLATE data in a two-byte header and
+        // a four-byte Adler-32 checksum. DeflateStream expects the raw payload.
+        var hasPresetDictionary = (response[1] & 0x20) != 0;
+        if (hasPresetDictionary)
+        {
+            throw new InvalidDataException("The SPT server response uses an unsupported zlib preset dictionary.");
+        }
+
+        using var compressed = new MemoryStream(response, 2, response.Length - 6, false);
+        using var deflate = new DeflateStream(compressed, CompressionMode.Decompress);
+        using var decompressed = new MemoryStream();
+        deflate.CopyTo(decompressed);
+        return decompressed.ToArray();
+    }
+
+    private static bool HasZlibHeader(byte[] response)
+    {
+        if (response.Length < 6)
+        {
+            return false;
+        }
+
+        var compressionMethod = response[0] & 0x0F;
+        var compressionInfo = response[0] >> 4;
+        var headerChecksum = (response[0] << 8) + response[1];
+
+        return compressionMethod == 8 && compressionInfo <= 7 && headerChecksum % 31 == 0;
+    }
+
+    private static void EnsureHandle(IntPtr handle, string operation)
+    {
+        if (handle == IntPtr.Zero)
+        {
+            ThrowLastError(operation);
+        }
+    }
+
+    private static void CloseHandle(IntPtr handle)
+    {
+        if (handle != IntPtr.Zero)
+        {
+            WinHttpCloseHandle(handle);
+        }
+    }
+
+    private static void ThrowLastError(string operation)
+    {
+        throw new Win32Exception(Marshal.GetLastWin32Error(), $"Failed to {operation}");
+    }
+
+    [DllImport("winhttp.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr WinHttpOpen(string userAgent, uint accessType, string? proxyName, string? proxyBypass, uint flags);
+
+    [DllImport("winhttp.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr WinHttpConnect(IntPtr session, string serverName, ushort serverPort, uint reserved);
+
+    [DllImport("winhttp.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr WinHttpOpenRequest(
+        IntPtr connection,
+        string verb,
+        string objectName,
+        string? version,
+        string? referrer,
+        IntPtr acceptTypes,
+        uint flags
+    );
+
+    [DllImport("winhttp.dll", SetLastError = true)]
+    private static extern bool WinHttpSetTimeouts(
+        IntPtr handle,
+        int resolveTimeout,
+        int connectTimeout,
+        int sendTimeout,
+        int receiveTimeout
+    );
+
+    [DllImport("winhttp.dll", SetLastError = true)]
+    private static extern bool WinHttpSetOption(IntPtr handle, uint option, ref uint buffer, uint bufferLength);
+
+    [DllImport("winhttp.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool WinHttpSendRequest(
+        IntPtr request,
+        string? headers,
+        uint headersLength,
+        IntPtr optional,
+        uint optionalLength,
+        uint totalLength,
+        IntPtr context
+    );
+
+    [DllImport("winhttp.dll", SetLastError = true)]
+    private static extern bool WinHttpReceiveResponse(IntPtr request, IntPtr reserved);
+
+    [DllImport("winhttp.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern bool WinHttpQueryHeaders(
+        IntPtr request,
+        uint infoLevel,
+        string? name,
+        ref uint buffer,
+        ref uint bufferLength,
+        IntPtr index
+    );
+
+    [DllImport("winhttp.dll", SetLastError = true)]
+    private static extern bool WinHttpQueryDataAvailable(IntPtr request, out uint available);
+
+    [DllImport("winhttp.dll", SetLastError = true)]
+    private static extern bool WinHttpReadData(IntPtr request, [Out] byte[] buffer, uint bytesToRead, out uint bytesRead);
+
+    [DllImport("winhttp.dll", SetLastError = true)]
+    private static extern bool WinHttpCloseHandle(IntPtr handle);
+}


### PR DESCRIPTION
Must be merged with the server PR of the same name.

- Mono HTTP providers(TLS) are not available that early in the runtime process, thus had to resort to using winhttp.
- It gets the backend URL from the games launch params. So this is Fika compatible.